### PR TITLE
cli and regex patch

### DIFF
--- a/hardlink_folders.py
+++ b/hardlink_folders.py
@@ -1,37 +1,42 @@
 import os
 import re
 import datetime
-import logging
+import argparse
 
 
 def handle_files(file_name, patch_dir, base_files, destination_dir):
-    match = re.search(r'(\d{7})', file_name) 
-    if match:
-        file_suffix = match.group(1)
-        file_path = os.path.join(patch_dir, file_name)
+    file_name_no_ext = os.path.splitext(file_name)[0]
+    digits = ""
+    for char in reversed(file_name_no_ext):
+        if char.isdigit():
+            digits = char + digits
+        else:
+            break
+    last_7_digits = digits[-7:]
+    file_suffix = last_7_digits.zfill(7)
 
-        corresponding_base_file = None
-        for base_file in base_files:
-            if file_suffix in base_file:
-                corresponding_base_file = base_file
-                break
+    file_path = os.path.join(patch_dir, file_name)
 
-        if corresponding_base_file:
-            destination_file_path = os.path.join(destination_dir, corresponding_base_file)
-            if os.path.exists(destination_file_path):
-                print('Destination file exists, removing: %s', destination_file_path)
-                os.remove(destination_file_path)
-            os.link(file_path, destination_file_path)
+    corresponding_base_file = None
+    for base_file in base_files:
+        if file_suffix in base_file:
+            corresponding_base_file = base_file
+            break
 
-def create_new_folder(base_tiff, patch_tiff, destination_parent):
+    if corresponding_base_file:
+        destination_file_path = os.path.join(destination_dir, corresponding_base_file)
+        if os.path.exists(destination_file_path):
+            print('Destination file exists, removing: %s', destination_file_path)
+            os.remove(destination_file_path)
+        os.link(file_path, destination_file_path)
+
+def create_new_folder(base_tiff, patch_tiff, destination_parent,folders_to_handle):
     current_time = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
     destination_folder = os.path.join(destination_parent, current_time)
     
     if not os.path.exists(destination_folder):
         os.makedirs(destination_folder)
         print('Folder created', destination_folder)
-
-    folders_to_handle = ['TXTD','TXLS']
 
     for folder in folders_to_handle:
         base_dir = os.path.join(base_tiff, folder)
@@ -53,12 +58,17 @@ def create_new_folder(base_tiff, patch_tiff, destination_parent):
         if os.path.exists(patch_dir):
             patch_files = os.listdir(patch_dir)
             for file_name in patch_files:
+                print('Handling file', file_name)
                 handle_files(file_name, patch_dir, base_files, destination_dir)
 
     print(f"Folder {destination_folder} created with hardlinks to assets from BaseTIFF and PatchTIFF.")
 
-Base_TIFF_Location = "./testfolders/BaseTIFF"
-Patch_TIFF_Location = "./testfolders/PatchTIFF"
-New_Folder_Location = "./testfolders"
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Process some TIFF files.")
+    parser.add_argument("-b", "--base_tiff_location", type=str, default="./testfolders/BaseTIFF", help="Base TIFF location")
+    parser.add_argument("-p", "--patch_tiff_location", type=str, default="./testfolders/PatchTIFF", help="Patch TIFF location")
+    parser.add_argument("-n", "--new_folder_location", type=str, default="./testfolders", help="New folder location")
 
-create_new_folder(Base_TIFF_Location, Patch_TIFF_Location, New_Folder_Location)
+    args = parser.parse_args()
+
+    create_new_folder(args.base_tiff_location, args.patch_tiff_location, args.new_folder_location, folders_to_handle=['TXTD','TXLS'])


### PR DESCRIPTION
Conducted the 2 improvements requested:

1. Make sure you add command line variables that can be used to adjust the input directories right now I see that they are hard coded

2. For the regex, I think another solution we could use for that is using pythons built in common name, to get the name that matches the rest of the files in the folder, since I think the regex will break if they don’t actually have 7 numbers at the end of the file. 